### PR TITLE
chore: adaptations to the internals API following migration to SQLite

### DIFF
--- a/lib/model/mocks/model.go
+++ b/lib/model/mocks/model.go
@@ -24,6 +24,19 @@ type Model struct {
 		arg1 protocol.Connection
 		arg2 protocol.Hello
 	}
+	AllGlobalFilesStub        func(string) (iter.Seq[db.FileMetadata], func() error)
+	allGlobalFilesMutex       sync.RWMutex
+	allGlobalFilesArgsForCall []struct {
+		arg1 string
+	}
+	allGlobalFilesReturns struct {
+		result1 iter.Seq[db.FileMetadata]
+		result2 func() error
+	}
+	allGlobalFilesReturnsOnCall map[int]struct {
+		result1 iter.Seq[db.FileMetadata]
+		result2 func() error
+	}
 	AvailabilityStub        func(string, protocol.FileInfo, protocol.BlockInfo) ([]model.Availability, error)
 	availabilityMutex       sync.RWMutex
 	availabilityArgsForCall []struct {
@@ -682,6 +695,70 @@ func (fake *Model) AddConnectionArgsForCall(i int) (protocol.Connection, protoco
 	defer fake.addConnectionMutex.RUnlock()
 	argsForCall := fake.addConnectionArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *Model) AllGlobalFiles(arg1 string) (iter.Seq[db.FileMetadata], func() error) {
+	fake.allGlobalFilesMutex.Lock()
+	ret, specificReturn := fake.allGlobalFilesReturnsOnCall[len(fake.allGlobalFilesArgsForCall)]
+	fake.allGlobalFilesArgsForCall = append(fake.allGlobalFilesArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.AllGlobalFilesStub
+	fakeReturns := fake.allGlobalFilesReturns
+	fake.recordInvocation("AllGlobalFiles", []interface{}{arg1})
+	fake.allGlobalFilesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Model) AllGlobalFilesCallCount() int {
+	fake.allGlobalFilesMutex.RLock()
+	defer fake.allGlobalFilesMutex.RUnlock()
+	return len(fake.allGlobalFilesArgsForCall)
+}
+
+func (fake *Model) AllGlobalFilesCalls(stub func(string) (iter.Seq[db.FileMetadata], func() error)) {
+	fake.allGlobalFilesMutex.Lock()
+	defer fake.allGlobalFilesMutex.Unlock()
+	fake.AllGlobalFilesStub = stub
+}
+
+func (fake *Model) AllGlobalFilesArgsForCall(i int) string {
+	fake.allGlobalFilesMutex.RLock()
+	defer fake.allGlobalFilesMutex.RUnlock()
+	argsForCall := fake.allGlobalFilesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Model) AllGlobalFilesReturns(result1 iter.Seq[db.FileMetadata], result2 func() error) {
+	fake.allGlobalFilesMutex.Lock()
+	defer fake.allGlobalFilesMutex.Unlock()
+	fake.AllGlobalFilesStub = nil
+	fake.allGlobalFilesReturns = struct {
+		result1 iter.Seq[db.FileMetadata]
+		result2 func() error
+	}{result1, result2}
+}
+
+func (fake *Model) AllGlobalFilesReturnsOnCall(i int, result1 iter.Seq[db.FileMetadata], result2 func() error) {
+	fake.allGlobalFilesMutex.Lock()
+	defer fake.allGlobalFilesMutex.Unlock()
+	fake.AllGlobalFilesStub = nil
+	if fake.allGlobalFilesReturnsOnCall == nil {
+		fake.allGlobalFilesReturnsOnCall = make(map[int]struct {
+			result1 iter.Seq[db.FileMetadata]
+			result2 func() error
+		})
+	}
+	fake.allGlobalFilesReturnsOnCall[i] = struct {
+		result1 iter.Seq[db.FileMetadata]
+		result2 func() error
+	}{result1, result2}
 }
 
 func (fake *Model) Availability(arg1 string, arg2 protocol.FileInfo, arg3 protocol.BlockInfo) ([]model.Availability, error) {
@@ -3688,6 +3765,8 @@ func (fake *Model) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.addConnectionMutex.RLock()
 	defer fake.addConnectionMutex.RUnlock()
+	fake.allGlobalFilesMutex.RLock()
+	defer fake.allGlobalFilesMutex.RUnlock()
 	fake.availabilityMutex.RLock()
 	defer fake.availabilityMutex.RUnlock()
 	fake.bringToFrontMutex.RLock()

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -126,6 +126,7 @@ type Model interface {
 	DismissPendingDevice(device protocol.DeviceID) error
 	DismissPendingFolder(device protocol.DeviceID, folder string) error
 
+	AllGlobalFiles(folder string) (iter.Seq[db.FileMetadata], func() error)
 	GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly bool) ([]*TreeEntry, error)
 
 	RequestGlobal(ctx context.Context, deviceID protocol.DeviceID, folder, name string, blockNo int, offset int64, size int, hash []byte, weakHash uint32, fromTemporary bool) ([]byte, error)
@@ -2774,6 +2775,10 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly 
 	}
 
 	return root.Children, nil
+}
+
+func (m *model) AllGlobalFiles(folder string) (iter.Seq[db.FileMetadata], func() error) {
+	return m.sdb.AllGlobalFiles(folder)
 }
 
 func (m *model) GetFolderVersions(folder string) (map[string][]versioner.FileVersion, error) {

--- a/lib/syncthing/internals.go
+++ b/lib/syncthing/internals.go
@@ -25,16 +25,7 @@ type Internals struct {
 	model model.Model
 }
 
-// Exposed version of db.Counts, which is now internal
-type Counts struct {
-	Files       int
-	Directories int
-	Symlinks    int
-	Deleted     int
-	Bytes       int64
-	Sequence    int64             // zero for the global state
-	DeviceID    protocol.DeviceID // device ID for remote devices, or special values for local/global
-}
+type Counts = db.Counts
 
 func newInternals(model model.Model) *Internals {
 	return &Internals{
@@ -99,7 +90,7 @@ func (m *Internals) GlobalSize(folder string) (Counts, error) {
 	if err != nil {
 		return Counts{}, err
 	}
-	return newCounts(counts), nil
+	return counts, nil
 }
 
 func (m *Internals) LocalSize(folder string) (Counts, error) {
@@ -107,7 +98,7 @@ func (m *Internals) LocalSize(folder string) (Counts, error) {
 	if err != nil {
 		return Counts{}, err
 	}
-	return newCounts(counts), nil
+	return counts, nil
 }
 
 func (m *Internals) NeedSize(folder string, device protocol.DeviceID) (Counts, error) {
@@ -115,21 +106,9 @@ func (m *Internals) NeedSize(folder string, device protocol.DeviceID) (Counts, e
 	if err != nil {
 		return Counts{}, err
 	}
-	return newCounts(counts), nil
+	return counts, nil
 }
 
 func (m *Internals) AllGlobalFiles(folder string) (iter.Seq[db.FileMetadata], func() error) {
 	return m.model.AllGlobalFiles(folder)
-}
-
-func newCounts(counts db.Counts) Counts {
-	return Counts{
-		Files:       counts.Files,
-		Directories: counts.Directories,
-		Symlinks:    counts.Symlinks,
-		Deleted:     counts.Deleted,
-		Bytes:       counts.Bytes,
-		Sequence:    counts.Sequence,
-		DeviceID:    counts.DeviceID,
-	}
 }

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -171,7 +171,12 @@ func OpenDatabase(path string, oldDBDir string, evLogger events.Logger) (newdb.D
 
 	if be, err := backend.OpenLevelDBRO(oldDBDir); err == nil {
 		// We have not migrated. We should do that.
-		migrateDatabase(be, evLogger, sdb, oldDBDir)
+		err := migrateDatabase(be, evLogger, sdb, oldDBDir)
+		if err != nil {
+			l.Warnln(err.Error())
+			os.Exit(0) // prevent automatic restart by the monitor
+		}
+
 		miscDB := dbext.NewMiscDB(sdb)
 		_ = miscDB.PutTime("migrated-from-leveldb-at", time.Now())
 		_ = miscDB.PutString("migrated-from-leveldb-by", build.LongVersion)
@@ -180,13 +185,12 @@ func OpenDatabase(path string, oldDBDir string, evLogger events.Logger) (newdb.D
 	return sdb, nil
 }
 
-func migrateDatabase(be backend.Backend, evLogger events.Logger, sdb newdb.DB, oldDBDir string) {
+func migrateDatabase(be backend.Backend, evLogger events.Logger, sdb newdb.DB, oldDBDir string) error {
 	l.Infoln("Migrating database from LevelDB to SQLite; this can take quite a while...")
 
 	ll, err := db.NewLowlevel(be, evLogger)
 	if err != nil {
-		l.Warnln("Failed to migrate:", err)
-		os.Exit(1)
+		return errors.New("Failed to migrate: " + err.Error())
 	}
 
 	for _, folder := range ll.ListFolders() {
@@ -194,29 +198,33 @@ func migrateDatabase(be backend.Backend, evLogger events.Logger, sdb newdb.DB, o
 		var batch []protocol.FileInfo
 		fs, err := db.NewFileSet(folder, ll)
 		if err != nil {
-			l.Warnln("Failed to migrate FileInfos:", err)
-			os.Exit(1)
+			return errors.New("Failed to migrate FileInfos: " + err.Error())
 		}
+
 		snap, err := fs.Snapshot()
 		if err != nil {
-			l.Warnln("Failed to migrate FileInfos:", err)
-			os.Exit(1)
+			return errors.New("Failed to migrate FileInfos: " + err.Error())
 		}
+
+		err = nil
 		snap.WithHaveSequence(0, func(f protocol.FileInfo) bool {
 			batch = append(batch, f)
 			if len(batch) == 1000 {
-				if err := sdb.Update(folder, protocol.LocalDeviceID, batch); err != nil {
-					l.Warnln("Failed to migrate FileInfos:", err)
-					os.Exit(1)
+				if err = sdb.Update(folder, protocol.LocalDeviceID, batch); err != nil {
+					return false
 				}
 				batch = batch[:0]
 			}
 			return true
 		})
+
+		if err != nil {
+			return errors.New("Failed to migrate FileInfos: " + err.Error())
+		}
+
 		if len(batch) > 0 {
 			if err := sdb.Update(folder, protocol.LocalDeviceID, batch); err != nil {
-				l.Warnln("Failed to migrate FileInfos:", err)
-				os.Exit(1)
+				return errors.New("Failed to migrate FileInfos: " + err.Error())
 			}
 		}
 		snap.Release()
@@ -231,7 +239,8 @@ func migrateDatabase(be backend.Backend, evLogger events.Logger, sdb newdb.DB, o
 	be.Close()
 
 	if err := os.Rename(oldDBDir, oldDBDir+"-migrated"); err != nil {
-		l.Warnln("Failed to rename old, migrated database; please manually move or remove", oldDBDir)
-		os.Exit(0) // prevent automatic restart by the monitor
+		return errors.New("Failed to rename old, migrated database: " + err.Error() + ". Please manually move or remove " + oldDBDir)
 	}
+
+	return nil
 }

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -12,8 +12,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
+	newdb "github.com/syncthing/syncthing/internal/db"
+	"github.com/syncthing/syncthing/internal/db/dbext"
+	"github.com/syncthing/syncthing/internal/db/sqlite"
+	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/db/backend"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
@@ -152,4 +158,80 @@ func copyFile(src, dst string) error {
 
 func OpenDBBackend(path string, tuning config.Tuning) (backend.Backend, error) {
 	return backend.Open(path, backend.Tuning(tuning))
+}
+
+// Opens a database and attempts migrating the legacy database to the new database format.
+func OpenDatabase(path string, oldDBDir string, evLogger events.Logger) (newdb.DB, error) {
+	sql, err := sqlite.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	sdb := newdb.MetricsWrap(sql)
+
+	if be, err := backend.OpenLevelDBRO(oldDBDir); err == nil {
+		// We have not migrated. We should do that.
+		migrateDatabase(be, evLogger, sdb, oldDBDir)
+		miscDB := dbext.NewMiscDB(sdb)
+		_ = miscDB.PutTime("migrated-from-leveldb-at", time.Now())
+		_ = miscDB.PutString("migrated-from-leveldb-by", build.LongVersion)
+	}
+
+	return sdb, nil
+}
+
+func migrateDatabase(be backend.Backend, evLogger events.Logger, sdb newdb.DB, oldDBDir string) {
+	l.Infoln("Migrating database from LevelDB to SQLite; this can take quite a while...")
+
+	ll, err := db.NewLowlevel(be, evLogger)
+	if err != nil {
+		l.Warnln("Failed to migrate:", err)
+		os.Exit(1)
+	}
+
+	for _, folder := range ll.ListFolders() {
+		l.Infoln("Migrating folder", folder, "...")
+		var batch []protocol.FileInfo
+		fs, err := db.NewFileSet(folder, ll)
+		if err != nil {
+			l.Warnln("Failed to migrate FileInfos:", err)
+			os.Exit(1)
+		}
+		snap, err := fs.Snapshot()
+		if err != nil {
+			l.Warnln("Failed to migrate FileInfos:", err)
+			os.Exit(1)
+		}
+		snap.WithHaveSequence(0, func(f protocol.FileInfo) bool {
+			batch = append(batch, f)
+			if len(batch) == 1000 {
+				if err := sdb.Update(folder, protocol.LocalDeviceID, batch); err != nil {
+					l.Warnln("Failed to migrate FileInfos:", err)
+					os.Exit(1)
+				}
+				batch = batch[:0]
+			}
+			return true
+		})
+		if len(batch) > 0 {
+			if err := sdb.Update(folder, protocol.LocalDeviceID, batch); err != nil {
+				l.Warnln("Failed to migrate FileInfos:", err)
+				os.Exit(1)
+			}
+		}
+		snap.Release()
+	}
+
+	l.Infoln("Migrating virtual mtimes...")
+	if err := ll.IterateMtimes(sdb.MtimePut); err != nil {
+		l.Warnln("Failed to migrate mtimes:", err)
+	}
+
+	l.Infoln("Migration complete")
+	be.Close()
+
+	if err := os.Rename(oldDBDir, oldDBDir+"-migrated"); err != nil {
+		l.Warnln("Failed to rename old, migrated database; please manually move or remove", oldDBDir)
+		os.Exit(0) // prevent automatic restart by the monitor
+	}
 }


### PR DESCRIPTION
Hi @calmh, great work on the SQLite backend!

I spent the morning getting the Synctrain iOS app to build with this branch as well, and as expected there were some minor things to fix. This PR contains all the fixes currently needed:

* Due to the removal of `internals.DBSnapshot()` (which is a good move I think), I added two new functions to obtain the required statistics (`LocalSize` and `NeedSize`). Due to the `Counts` type now being moved to `internals` I have added a proxy type here so the internal `db.Counts` can be left unexposed.
* Due to the removal of `internals.DBSnapshot()`, it cannot be used anymore to iterate over the global list of files.  Therefore I added a function `AllGlobalFiles` to expose the equally named function from `Model` to iterate over files. 
* To be able to call `syncthing.New` from the iOS side, I need a way to instantiate the new `sdb` and of course would like a way to trigger the migration as well. I therefore created a function `utils.OpenDatabase` that does this (before my change the code for migrating and upgrading was a bit intermingled - I don't need to/can't do auto-upgrading so I left this unexposed).

Everything seems to work fine, but I need to do further testing obviously. 

I think it would be great if you could already in this early stage incorporate these changes. This would allow me to track the progress on the SQLite migration and ensure the iOS app is ready as well whenever v2.0.0 is.