### PR TITLE
fix: do not require passing a miscDB to TryMigrateDatabase

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -599,8 +599,7 @@ func syncthingMain(options serveOptions) {
 		os.Exit(1)
 	}
 
-	miscDB := db.NewMiscDB(sdb)
-	if err := syncthing.TryMigrateDatabase(sdb, miscDB, locations.Get(locations.LegacyDatabase)); err != nil {
+	if err := syncthing.TryMigrateDatabase(sdb, locations.Get(locations.LegacyDatabase)); err != nil {
 		l.Warnln("Failed to migrate old-style database:", err)
 		os.Exit(1)
 	}
@@ -611,6 +610,7 @@ func syncthingMain(options serveOptions) {
 	autoUpgradePossible := autoUpgradePossible(options)
 	if autoUpgradePossible && cfgWrapper.Options().AutoUpgradeEnabled() {
 		// try to do upgrade directly and log the error if relevant.
+		miscDB := db.NewMiscDB(sdb)
 		release, err := initialAutoUpgradeCheck(miscDB)
 		if err == nil {
 			err = upgrade.To(release)


### PR DESCRIPTION
The `miscDB` cannot be created externally because it is an internal type. 

The suggested solution is to not require passing `miscDB` to `TryMigrateDatabase`. When `nil` is passed, the function will create its own instance. 

The alternative would be to not even accept a `miscDB` and let `TryMigrateDatabase` always construct it.

Also note I fixed the comment for `OpenDatabase`, as it does not attempt migration anymore, you now have to call `TryMigrateDatabase` yourself.